### PR TITLE
Fix for BRK not dispatching to the IRQ handler.

### DIFF
--- a/CPU/Memory.py
+++ b/CPU/Memory.py
@@ -8,41 +8,42 @@ from struct import unpack
 class InvalidAddressException(Exception):
     def __init__(self, address):
         self.address = address
-        
+
     def __repr__(self):
         return "Invalid address: %s" % hex(self.address)
 
 class ValueOutOfRange(Exception):
     def __init__(self, value):
         self.value = value
-        
+
     def __repr__(self):
         return "Value out of range: %s" % hex(self.value)
-        
+
 class Memory(object):
     class Map(object):
         def __init__(self, range, callback):
             self.range = range
             self.callback = callback
-            
+
         def base(self):
             return self.range[0]
-        
+
         def end(self):
+            # Note: end is inclusive
             return self.range[1]
-        
+
         def isInMap(self, address):
-            return True if address >= self.base() and address < self.end()  else False
-    
+            return True if address >= self.base() and address <= self.end()  else False
+
     MEMORYSIZE = 64 * 1024
     def __init__(self):
         self.memory = bytearray(self.MEMORYSIZE)
         self.protection = bytearray(self.MEMORYSIZE)
         self.maps = []
-        
+
     def map(self, range, callback):
         self.maps.append( self.Map(range, callback) )
-        
+
     def unmap(self, range):
         raise BaseException("Cannae do this")
 
@@ -52,14 +53,14 @@ class Memory(object):
             return maps[-1]
         else:
             return None
-                
+
     def readByte(self, address):
         # TODO - add memory mapping
         if address < 0 or address > 0xffff:
             raise InvalidAddressException(address)
-        
+
         map = self.getMapFor(address)
-        
+
         if map != None:
             base = map.base()
             mappedDevice = map.callback
@@ -69,12 +70,12 @@ class Memory(object):
 
         #print "Read byte %s from %s" % (hex(readByte) , hex(address))
         return readByte
-    
+
     def writeByte(self, address, value):
         # TODO - add memory mapping
         if address < 0 or address > 0xffff:
             raise InvalidAddressException(address)
-        
+
         if value < 0 or value > 0xff:
             raise ValueOutOfRange(value)
 
@@ -85,10 +86,10 @@ class Memory(object):
             mappedDevice.writeByte(address - base, value)
         else:
             self.memory[address] = value
-        
+
     def readSignedByte(self, address):
         b = self.readByte(address)
         return unpack("b", chr(b))[0]
-    
+
     def readWord(self, address):
         return self.readByte(address) + (self.readByte(address + 1) << 8)


### PR DESCRIPTION
The last address in the memory map regions would not be supplied - the check for whether the memory was in the mapped object was not allowing for the inclusive end address of the mapping. This meant that the IRQ entry point (which is used by BRK) would be called with the high address byte being returned from the standard memory, which was 0. Instead of calling &DC1C, it was calling &001C.

We now check the memory region inclusively.